### PR TITLE
'NoneType' object is not subscriptable 🐛️

### DIFF
--- a/check-strand.py
+++ b/check-strand.py
@@ -73,8 +73,8 @@ def main():
     
     samples = pd.read_csv(samples_fp)
     
-    num_reads = args['num-reads'][0]
-    num_threads = args['threads'][0]
+    num_reads = args['num-reads']
+    num_threads = args['threads']
     
     if num_reads is None:
         num_reads = DEFAULT_NREADS


### PR DESCRIPTION
When I was leaving num-reads and threads arguments empty the TypeError: 'NoneType' object is not subscriptable would come up. I just defined the arguments to get it to work but removing the [0] fixed the empty default.